### PR TITLE
Fix roulette parsing error

### DIFF
--- a/api/lib/aleo_roulette_api/roulette/leo_io.ex
+++ b/api/lib/aleo_roulette_api/roulette/leo_io.ex
@@ -11,7 +11,7 @@ defmodule AleoRouletteApi.Roulette.LeoIO do
   def bets_to_leo_input(bet_number, credits) do
     bet_number = String.to_integer(bet_number)
     base_string = "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
-    String.slice(base_string,0..((bet_number - 1) * 3)) <> credits <>  String.slice(base_string,bet_number * 3 + 1 + String.length(credits)..-1)
+    String.slice(base_string,0..((bet_number - 1) * 3)) <> credits <>  String.slice(base_string,bet_number * 3 + 2..-1) |> IO.inspect()
   end
 
   def wait_for_leo_poseidon() do


### PR DESCRIPTION
fixes # 14

There was an error in the generation of the input for Leo. The number of credits in the bet overwrote the next characters of the array if it was longer than one digit, making an invalid input for Leo.

In such case, Leo wasn't able to generate an output, and so the request hanged, with the server waiting for a result from Leo that it never gets.